### PR TITLE
Fix identity service path

### DIFF
--- a/src/config/default.ts
+++ b/src/config/default.ts
@@ -26,7 +26,7 @@ export const content = {
     client: {
         hostName: 'localhost',
         port: 8085,
-        path: '/',
+        path: '/thrift',
     },
 }
 


### PR DESCRIPTION
Hi! Thanks for the tutorial.

At the moment:

```
curl http://localhost:9000/post/1
```

gives:

```
Debug: handler, error
    {"msec":0.7726290002465248,"error":"Not Found","data":{"data":null,"isBoom":true,"isServer":false,"output":{"statusCode":404,"payload":{"statusCode":404,"error":"Not Found","message":"Not Found"},"headers":{}},"message":"Not Found"}}
```

This PR fixes the problem for me. [`ThriftServerHapi` adds a Thrift route handler to the '/thrift' path](https://github.com/kevinbgreene/thrift-tutorial/blob/master/src/identity/server.ts#L57) and hence config should have it accordingly.

Another way to change path from `/thrift` to `/` in `identity/server.ts`